### PR TITLE
add xlsx-clip-watcher launchd agent

### DIFF
--- a/launchd/agents/com.joshuashew.xlsx-clip-watcher.plist.template
+++ b/launchd/agents/com.joshuashew.xlsx-clip-watcher.plist.template
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.joshuashew.xlsx-clip-watcher</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>$HOME/.dotfiles/launchd/scripts/xlsx-clip-watcher.sh</string>
+    </array>
+    <key>WatchPaths</key>
+    <array>
+        <string>$HOME/Downloads</string>
+    </array>
+    <key>RunAtLoad</key>
+    <false/>
+    <key>StandardOutPath</key>
+    <string>/tmp/xlsx-clip-watcher.log</string>
+    <key>StandardErrorPath</key>
+    <string>/tmp/xlsx-clip-watcher.log</string>
+</dict>
+</plist>

--- a/launchd/install-xlsx-clip-watcher.sh
+++ b/launchd/install-xlsx-clip-watcher.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# install-xlsx-clip-watcher.sh — installs and loads com.joshuashew.xlsx-clip-watcher
+
+set -euo pipefail
+
+DOTFILES_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")/.." && pwd)"
+TEMPLATE="$DOTFILES_DIR/launchd/agents/com.joshuashew.xlsx-clip-watcher.plist.template"
+PLIST_DIR="$HOME/Library/LaunchAgents"
+PLIST_DEST="$PLIST_DIR/com.joshuashew.xlsx-clip-watcher.plist"
+LABEL="com.joshuashew.xlsx-clip-watcher"
+
+echo "=== install-xlsx-clip-watcher $(date +%H:%M:%S) ==="
+echo "  dotfiles: $DOTFILES_DIR"
+
+mkdir -p "$PLIST_DIR"
+sed "s|\$HOME|$HOME|g" "$TEMPLATE" > "$PLIST_DEST"
+echo "  plist written: $PLIST_DEST"
+
+chmod +x "$DOTFILES_DIR/launchd/scripts/xlsx-clip-watcher.sh"
+echo "  script marked executable"
+
+if launchctl list | grep -q "$LABEL"; then
+    launchctl unload "$PLIST_DEST" 2>/dev/null || true
+    echo "  unloaded previous version"
+fi
+
+launchctl load "$PLIST_DEST"
+echo "  loaded: $LABEL"
+echo ""
+echo "Log:   tail -f /tmp/xlsx-clip-watcher.log"
+echo "State: $HOME/.local/state/xlsx-clip-watcher/seen.txt"
+echo ""
+echo "Done. Drop an .xlsx file < 500KB into ~/Downloads to test."

--- a/launchd/scripts/xlsx-clip-watcher.sh
+++ b/launchd/scripts/xlsx-clip-watcher.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# xlsx-clip-watcher — fires when ~/Downloads changes via launchd WatchPaths
+# Runs clip import xlsx if any new .xlsx < 500KB has appeared since last run.
+# Tracks files by device:inode so a re-downloaded file with the same name
+# counts as new.
+
+export PATH="$HOME/.local/bin:$HOME/bin:$HOME/.dotfiles/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin"
+
+DOWNLOADS="$HOME/Downloads"
+STATE_DIR="$HOME/.local/state/xlsx-clip-watcher"
+SEEN_FILE="$STATE_DIR/seen.txt"
+
+mkdir -p "$STATE_DIR"
+
+new_inodes=()
+
+while IFS= read -r -d '' file; do
+    size=$(stat -f "%z" "$file" 2>/dev/null) || continue
+    [ "$size" -ge 512000 ] && continue
+
+    dev_inode=$(stat -f "%d:%i" "$file" 2>/dev/null) || continue
+
+    if ! grep -qxF "$dev_inode" "$SEEN_FILE" 2>/dev/null; then
+        echo "[xlsx-clip-watcher] $(date '+%Y-%m-%d %H:%M:%S') new: $(basename "$file") (${size}B inode=$dev_inode)"
+        new_inodes+=("$dev_inode")
+    fi
+done < <(find "$DOWNLOADS" -maxdepth 1 -name "*.xlsx" -print0 2>/dev/null)
+
+if [ "${#new_inodes[@]}" -gt 0 ]; then
+    echo "[xlsx-clip-watcher] $(date '+%Y-%m-%d %H:%M:%S') running: clip import xlsx -d $DOWNLOADS"
+    if clip import xlsx -d "$DOWNLOADS"; then
+        printf '%s\n' "${new_inodes[@]}" >> "$SEEN_FILE"
+    else
+        echo "[xlsx-clip-watcher] $(date '+%Y-%m-%d %H:%M:%S') clip exited non-zero — inodes not marked seen"
+    fi
+else
+    echo "[xlsx-clip-watcher] $(date '+%Y-%m-%d %H:%M:%S') no new xlsx"
+fi


### PR DESCRIPTION
Adds a launchd agent that fires whenever `~/Downloads` changes, checks for new `.xlsx` files under 500 KB (tracked by device+inode so re-downloads count as new), and runs `clip import xlsx -d ~/Downloads` when any appear.

**New files:**
- `launchd/scripts/xlsx-clip-watcher.sh` — watcher script (PATH-expanded, inode tracking)
- `launchd/agents/com.joshuashew.xlsx-clip-watcher.plist.template` — launchd plist with `$HOME` placeholder
- `launchd/install-xlsx-clip-watcher.sh` — substitutes `$HOME`, copies plist to `~/Library/LaunchAgents/`, loads via launchctl

Log: `/tmp/xlsx-clip-watcher.log`. State: `~/.local/state/xlsx-clip-watcher/seen.txt`.