### PR TITLE
add StartInterval 30 to xlsx-clip-watcher plist

### DIFF
--- a/launchd/agents/com.joshuashew.xlsx-clip-watcher.plist.template
+++ b/launchd/agents/com.joshuashew.xlsx-clip-watcher.plist.template
@@ -13,6 +13,8 @@
     <array>
         <string>$HOME/Downloads</string>
     </array>
+    <key>StartInterval</key>
+    <integer>30</integer>
     <key>RunAtLoad</key>
     <false/>
     <key>StandardOutPath</key>


### PR DESCRIPTION
WatchPaths misses browser download events: Chrome/Safari write a temp file then atomically rename to `.xlsx`. launchd coalesces these events and fires on the temp-file creation, not the rename. By the time the script runs, `find *.xlsx` finds nothing.

`StartInterval: 30` polls every 30 seconds as a fallback. The inode-tracking logic in the watcher script prevents duplicate clipboard copies — `clip` only runs when a new inode appears.