### PR TITLE
fix xlsx-clip-watcher: launchctl bootstrap + WatchPaths retry loop

### DIFF
--- a/launchd/install-xlsx-clip-watcher.sh
+++ b/launchd/install-xlsx-clip-watcher.sh
@@ -8,6 +8,7 @@ TEMPLATE="$DOTFILES_DIR/launchd/agents/com.joshuashew.xlsx-clip-watcher.plist.te
 PLIST_DIR="$HOME/Library/LaunchAgents"
 PLIST_DEST="$PLIST_DIR/com.joshuashew.xlsx-clip-watcher.plist"
 LABEL="com.joshuashew.xlsx-clip-watcher"
+DOMAIN="gui/$(id -u)"
 
 echo "=== install-xlsx-clip-watcher $(date +%H:%M:%S) ==="
 echo "  dotfiles: $DOTFILES_DIR"
@@ -20,12 +21,17 @@ chmod +x "$DOTFILES_DIR/launchd/scripts/xlsx-clip-watcher.sh"
 echo "  script marked executable"
 
 if launchctl list | grep -q "$LABEL"; then
-    launchctl unload "$PLIST_DEST" 2>/dev/null || true
+    launchctl bootout "$DOMAIN/$LABEL" 2>/dev/null || launchctl unload "$PLIST_DEST" 2>/dev/null || true
     echo "  unloaded previous version"
 fi
 
-launchctl load "$PLIST_DEST"
-echo "  loaded: $LABEL"
+if launchctl bootstrap "$DOMAIN" "$PLIST_DEST" 2>/dev/null; then
+    echo "  loaded: $LABEL (bootstrap)"
+else
+    launchctl load "$PLIST_DEST" 2>/dev/null || true
+    echo "  loaded: $LABEL (legacy load)"
+fi
+
 echo ""
 echo "Log:   tail -f /tmp/xlsx-clip-watcher.log"
 echo "State: $HOME/.local/state/xlsx-clip-watcher/seen.txt"

--- a/launchd/scripts/xlsx-clip-watcher.sh
+++ b/launchd/scripts/xlsx-clip-watcher.sh
@@ -3,36 +3,50 @@
 # Runs clip import xlsx if any new .xlsx < 500KB has appeared since last run.
 # Tracks files by device:inode so a re-downloaded file with the same name
 # counts as new.
+#
+# Retry logic: browsers write a temp file then rename to .xlsx. WatchPaths
+# fires on the temp file; this script retries for up to 6 seconds so it
+# catches the rename without needing a short StartInterval.
 
 export PATH="$HOME/.local/bin:$HOME/bin:$HOME/.dotfiles/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin"
 
 DOWNLOADS="$HOME/Downloads"
 STATE_DIR="$HOME/.local/state/xlsx-clip-watcher"
 SEEN_FILE="$STATE_DIR/seen.txt"
+MAX_WAIT=6
+INTERVAL=1
 
 mkdir -p "$STATE_DIR"
 
-new_inodes=()
+scan_new() {
+    new_inodes=()
+    while IFS= read -r -d '' file; do
+        size=$(stat -f "%z" "$file" 2>/dev/null) || continue
+        [ "$size" -ge 512000 ] && continue
+        dev_inode=$(stat -f "%d:%i" "$file" 2>/dev/null) || continue
+        if ! grep -qxF "$dev_inode" "$SEEN_FILE" 2>/dev/null; then
+            echo "[xlsx-clip-watcher] $(date '+%Y-%m-%d %H:%M:%S') new: $(basename "$file") (${size}B inode=$dev_inode)"
+            new_inodes+=("$dev_inode")
+        fi
+    done < <(find "$DOWNLOADS" -maxdepth 1 -name "*.xlsx" -print0 2>/dev/null)
+}
 
-while IFS= read -r -d '' file; do
-    size=$(stat -f "%z" "$file" 2>/dev/null) || continue
-    [ "$size" -ge 512000 ] && continue
-
-    dev_inode=$(stat -f "%d:%i" "$file" 2>/dev/null) || continue
-
-    if ! grep -qxF "$dev_inode" "$SEEN_FILE" 2>/dev/null; then
-        echo "[xlsx-clip-watcher] $(date '+%Y-%m-%d %H:%M:%S') new: $(basename "$file") (${size}B inode=$dev_inode)"
-        new_inodes+=("$dev_inode")
+elapsed=0
+while true; do
+    scan_new
+    if [ "${#new_inodes[@]}" -gt 0 ]; then
+        echo "[xlsx-clip-watcher] $(date '+%Y-%m-%d %H:%M:%S') running: clip import xlsx -d $DOWNLOADS"
+        if clip import xlsx -d "$DOWNLOADS"; then
+            printf '%s\n' "${new_inodes[@]}" >> "$SEEN_FILE"
+        else
+            echo "[xlsx-clip-watcher] $(date '+%Y-%m-%d %H:%M:%S') clip exited non-zero — inodes not marked seen"
+        fi
+        break
     fi
-done < <(find "$DOWNLOADS" -maxdepth 1 -name "*.xlsx" -print0 2>/dev/null)
-
-if [ "${#new_inodes[@]}" -gt 0 ]; then
-    echo "[xlsx-clip-watcher] $(date '+%Y-%m-%d %H:%M:%S') running: clip import xlsx -d $DOWNLOADS"
-    if clip import xlsx -d "$DOWNLOADS"; then
-        printf '%s\n' "${new_inodes[@]}" >> "$SEEN_FILE"
-    else
-        echo "[xlsx-clip-watcher] $(date '+%Y-%m-%d %H:%M:%S') clip exited non-zero — inodes not marked seen"
+    elapsed=$((elapsed + INTERVAL))
+    if [ "$elapsed" -ge "$MAX_WAIT" ]; then
+        echo "[xlsx-clip-watcher] $(date '+%Y-%m-%d %H:%M:%S') no new xlsx (waited ${MAX_WAIT}s)"
+        break
     fi
-else
-    echo "[xlsx-clip-watcher] $(date '+%Y-%m-%d %H:%M:%S') no new xlsx"
-fi
+    sleep "$INTERVAL"
+done


### PR DESCRIPTION
Two fixes:

1. **Installer**: `launchctl load/unload` → `launchctl bootstrap/bootout`. Legacy `load` returns I/O error 5 on modern macOS, so the StartInterval plist update never took effect.

2. **Script**: 6-second retry loop. WatchPaths fires on the temp `.crdownload` creation before the rename to `.xlsx`. Now the script retries every second for up to 6s, catching the rename as soon as it happens.