### PR TITLE
xlsx-clip-watcher: drop WatchPaths, poll every 5s

### DIFF
--- a/launchd/agents/com.joshuashew.xlsx-clip-watcher.plist.template
+++ b/launchd/agents/com.joshuashew.xlsx-clip-watcher.plist.template
@@ -9,12 +9,8 @@
         <string>/bin/bash</string>
         <string>$HOME/.dotfiles/launchd/scripts/xlsx-clip-watcher.sh</string>
     </array>
-    <key>WatchPaths</key>
-    <array>
-        <string>$HOME/Downloads</string>
-    </array>
     <key>StartInterval</key>
-    <integer>30</integer>
+    <integer>5</integer>
     <key>RunAtLoad</key>
     <false/>
     <key>StandardOutPath</key>

--- a/launchd/install-xlsx-clip-watcher.sh
+++ b/launchd/install-xlsx-clip-watcher.sh
@@ -23,9 +23,10 @@ echo "  script marked executable"
 if launchctl list | grep -q "$LABEL"; then
     launchctl bootout "$DOMAIN/$LABEL" 2>/dev/null || launchctl unload "$PLIST_DEST" 2>/dev/null || true
     echo "  unloaded previous version"
+    sleep 1
 fi
 
-if launchctl bootstrap "$DOMAIN" "$PLIST_DEST" 2>/dev/null; then
+if launchctl bootstrap "$DOMAIN" "$PLIST_DEST"; then
     echo "  loaded: $LABEL (bootstrap)"
 else
     launchctl load "$PLIST_DEST" 2>/dev/null || true
@@ -36,4 +37,4 @@ echo ""
 echo "Log:   tail -f /tmp/xlsx-clip-watcher.log"
 echo "State: $HOME/.local/state/xlsx-clip-watcher/seen.txt"
 echo ""
-echo "Done. Drop an .xlsx file < 500KB into ~/Downloads to test."
+echo "Done. Agent polls every 5s — clipboard updates within 5s of a new download."

--- a/launchd/scripts/xlsx-clip-watcher.sh
+++ b/launchd/scripts/xlsx-clip-watcher.sh
@@ -1,52 +1,33 @@
 #!/usr/bin/env bash
-# xlsx-clip-watcher — fires when ~/Downloads changes via launchd WatchPaths
+# xlsx-clip-watcher — polled by launchd every 5 seconds via StartInterval
 # Runs clip import xlsx if any new .xlsx < 500KB has appeared since last run.
 # Tracks files by device:inode so a re-downloaded file with the same name
 # counts as new.
-#
-# Retry logic: browsers write a temp file then rename to .xlsx. WatchPaths
-# fires on the temp file; this script retries for up to 6 seconds so it
-# catches the rename without needing a short StartInterval.
 
 export PATH="$HOME/.local/bin:$HOME/bin:$HOME/.dotfiles/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin"
 
 DOWNLOADS="$HOME/Downloads"
 STATE_DIR="$HOME/.local/state/xlsx-clip-watcher"
 SEEN_FILE="$STATE_DIR/seen.txt"
-MAX_WAIT=6
-INTERVAL=1
 
 mkdir -p "$STATE_DIR"
 
-scan_new() {
-    new_inodes=()
-    while IFS= read -r -d '' file; do
-        size=$(stat -f "%z" "$file" 2>/dev/null) || continue
-        [ "$size" -ge 512000 ] && continue
-        dev_inode=$(stat -f "%d:%i" "$file" 2>/dev/null) || continue
-        if ! grep -qxF "$dev_inode" "$SEEN_FILE" 2>/dev/null; then
-            echo "[xlsx-clip-watcher] $(date '+%Y-%m-%d %H:%M:%S') new: $(basename "$file") (${size}B inode=$dev_inode)"
-            new_inodes+=("$dev_inode")
-        fi
-    done < <(find "$DOWNLOADS" -maxdepth 1 -name "*.xlsx" -print0 2>/dev/null)
-}
+new_inodes=()
+while IFS= read -r -d '' file; do
+    size=$(stat -f "%z" "$file" 2>/dev/null) || continue
+    [ "$size" -ge 512000 ] && continue
+    dev_inode=$(stat -f "%d:%i" "$file" 2>/dev/null) || continue
+    if ! grep -qxF "$dev_inode" "$SEEN_FILE" 2>/dev/null; then
+        echo "[xlsx-clip-watcher] $(date '+%Y-%m-%d %H:%M:%S') new: $(basename "$file") (${size}B inode=$dev_inode)"
+        new_inodes+=("$dev_inode")
+    fi
+done < <(find "$DOWNLOADS" -maxdepth 1 -name "*.xlsx" -print0 2>/dev/null)
 
-elapsed=0
-while true; do
-    scan_new
-    if [ "${#new_inodes[@]}" -gt 0 ]; then
-        echo "[xlsx-clip-watcher] $(date '+%Y-%m-%d %H:%M:%S') running: clip import xlsx -d $DOWNLOADS"
-        if clip import xlsx -d "$DOWNLOADS"; then
-            printf '%s\n' "${new_inodes[@]}" >> "$SEEN_FILE"
-        else
-            echo "[xlsx-clip-watcher] $(date '+%Y-%m-%d %H:%M:%S') clip exited non-zero — inodes not marked seen"
-        fi
-        break
+if [ "${#new_inodes[@]}" -gt 0 ]; then
+    echo "[xlsx-clip-watcher] $(date '+%Y-%m-%d %H:%M:%S') running: clip import xlsx -d $DOWNLOADS"
+    if clip import xlsx -d "$DOWNLOADS"; then
+        printf '%s\n' "${new_inodes[@]}" >> "$SEEN_FILE"
+    else
+        echo "[xlsx-clip-watcher] $(date '+%Y-%m-%d %H:%M:%S') clip exited non-zero — inodes not marked seen"
     fi
-    elapsed=$((elapsed + INTERVAL))
-    if [ "$elapsed" -ge "$MAX_WAIT" ]; then
-        echo "[xlsx-clip-watcher] $(date '+%Y-%m-%d %H:%M:%S') no new xlsx (waited ${MAX_WAIT}s)"
-        break
-    fi
-    sleep "$INTERVAL"
-done
+fi


### PR DESCRIPTION
Drop WatchPaths entirely; use StartInterval: 5 as the sole trigger.

**Why:** `launchctl load` (legacy) silently discards WatchPaths and StartInterval trigger keys on macOS 12+. Even with `launchctl bootstrap`, WatchPaths only fired once (on the temp `.crdownload` before rename) and never reliably again. StartInterval: 5 is simpler, reliable, and gives ≤5s latency (average 2.5s) — fast enough for this workflow.

**Script:** removed the 6-second retry loop (only needed to compensate for WatchPaths timing). Now a clean scan-and-exit each poll cycle.

**Installer:** added `sleep 1` after `bootout` before `bootstrap` to avoid a race where the label is still registered.