### PR TITLE
xlsx-clip-watcher: KeepAlive continuous loop replaces StartInterval

### DIFF
--- a/launchd/agents/com.joshuashew.xlsx-clip-watcher.plist.template
+++ b/launchd/agents/com.joshuashew.xlsx-clip-watcher.plist.template
@@ -9,10 +9,10 @@
         <string>/bin/bash</string>
         <string>$HOME/.dotfiles/launchd/scripts/xlsx-clip-watcher.sh</string>
     </array>
-    <key>StartInterval</key>
-    <integer>5</integer>
+    <key>KeepAlive</key>
+    <true/>
     <key>RunAtLoad</key>
-    <false/>
+    <true/>
     <key>StandardOutPath</key>
     <string>/tmp/xlsx-clip-watcher.log</string>
     <key>StandardErrorPath</key>

--- a/launchd/scripts/xlsx-clip-watcher.sh
+++ b/launchd/scripts/xlsx-clip-watcher.sh
@@ -1,8 +1,7 @@
 #!/usr/bin/env bash
-# xlsx-clip-watcher — polled by launchd every 5 seconds via StartInterval
-# Runs clip import xlsx if any new .xlsx < 500KB has appeared since last run.
-# Tracks files by device:inode so a re-downloaded file with the same name
-# counts as new.
+# xlsx-clip-watcher — continuous poller, runs via KeepAlive launchd agent
+# Checks ~/Downloads every 5 seconds for new .xlsx < 500KB and runs
+# clip import xlsx if any are new. Tracks by device:inode.
 
 export PATH="$HOME/.local/bin:$HOME/bin:$HOME/.dotfiles/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin"
 
@@ -12,22 +11,26 @@ SEEN_FILE="$STATE_DIR/seen.txt"
 
 mkdir -p "$STATE_DIR"
 
-new_inodes=()
-while IFS= read -r -d '' file; do
-    size=$(stat -f "%z" "$file" 2>/dev/null) || continue
-    [ "$size" -ge 512000 ] && continue
-    dev_inode=$(stat -f "%d:%i" "$file" 2>/dev/null) || continue
-    if ! grep -qxF "$dev_inode" "$SEEN_FILE" 2>/dev/null; then
-        echo "[xlsx-clip-watcher] $(date '+%Y-%m-%d %H:%M:%S') new: $(basename "$file") (${size}B inode=$dev_inode)"
-        new_inodes+=("$dev_inode")
-    fi
-done < <(find "$DOWNLOADS" -maxdepth 1 -name "*.xlsx" -print0 2>/dev/null)
+while true; do
+    new_inodes=()
+    while IFS= read -r -d '' file; do
+        size=$(stat -f "%z" "$file" 2>/dev/null) || continue
+        [ "$size" -ge 512000 ] && continue
+        dev_inode=$(stat -f "%d:%i" "$file" 2>/dev/null) || continue
+        if ! grep -qxF "$dev_inode" "$SEEN_FILE" 2>/dev/null; then
+            echo "[xlsx-clip-watcher] $(date '+%Y-%m-%d %H:%M:%S') new: $(basename "$file") (${size}B inode=$dev_inode)"
+            new_inodes+=("$dev_inode")
+        fi
+    done < <(find "$DOWNLOADS" -maxdepth 1 -name "*.xlsx" -print0 2>/dev/null)
 
-if [ "${#new_inodes[@]}" -gt 0 ]; then
-    echo "[xlsx-clip-watcher] $(date '+%Y-%m-%d %H:%M:%S') running: clip import xlsx -d $DOWNLOADS"
-    if clip import xlsx -d "$DOWNLOADS"; then
-        printf '%s\n' "${new_inodes[@]}" >> "$SEEN_FILE"
-    else
-        echo "[xlsx-clip-watcher] $(date '+%Y-%m-%d %H:%M:%S') clip exited non-zero — inodes not marked seen"
+    if [ "${#new_inodes[@]}" -gt 0 ]; then
+        echo "[xlsx-clip-watcher] $(date '+%Y-%m-%d %H:%M:%S') running: clip import xlsx -d $DOWNLOADS"
+        if clip import xlsx -d "$DOWNLOADS"; then
+            printf '%s\n' "${new_inodes[@]}" >> "$SEEN_FILE"
+        else
+            echo "[xlsx-clip-watcher] $(date '+%Y-%m-%d %H:%M:%S') clip exited non-zero — inodes not marked seen"
+        fi
     fi
-fi
+
+    sleep 5
+done


### PR DESCRIPTION
Replace `StartInterval: 5` with `KeepAlive: true` + `RunAtLoad: true`. `launchctl bootstrap` consistently fails with error 5 on Joshua's machine; legacy `launchctl load` works but silently ignores `StartInterval` and `WatchPaths` trigger keys. `KeepAlive` + `RunAtLoad` only needs the script to *start* (which legacy load handles fine) — the script manages its own 5-second poll loop. No dependency on bootstrap.