### PR TITLE
installer: kickstart after load + crontab @reboot

### DIFF
--- a/launchd/install-xlsx-clip-watcher.sh
+++ b/launchd/install-xlsx-clip-watcher.sh
@@ -1,8 +1,6 @@
 #!/usr/bin/env bash
 # install-xlsx-clip-watcher.sh — installs and loads com.joshuashew.xlsx-clip-watcher
 
-set -euo pipefail
-
 DOTFILES_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")/.." && pwd)"
 TEMPLATE="$DOTFILES_DIR/launchd/agents/com.joshuashew.xlsx-clip-watcher.plist.template"
 PLIST_DIR="$HOME/Library/LaunchAgents"
@@ -20,21 +18,35 @@ echo "  plist written: $PLIST_DEST"
 chmod +x "$DOTFILES_DIR/launchd/scripts/xlsx-clip-watcher.sh"
 echo "  script marked executable"
 
-if launchctl list | grep -q "$LABEL"; then
-    launchctl bootout "$DOMAIN/$LABEL" 2>/dev/null || launchctl unload "$PLIST_DEST" 2>/dev/null || true
-    echo "  unloaded previous version"
-    sleep 1
-fi
+# Stop any running instance
+launchctl bootout "$DOMAIN/$LABEL" 2>/dev/null || launchctl unload "$PLIST_DEST" 2>/dev/null || true
+sleep 1
 
-if launchctl bootstrap "$DOMAIN" "$PLIST_DEST"; then
-    echo "  loaded: $LABEL (bootstrap)"
+# Register with launchd (bootstrap preferred, legacy fallback)
+if launchctl bootstrap "$DOMAIN" "$PLIST_DEST" 2>/dev/null; then
+    echo "  registered: $LABEL (bootstrap)"
 else
     launchctl load "$PLIST_DEST" 2>/dev/null || true
-    echo "  loaded: $LABEL (legacy load)"
+    echo "  registered: $LABEL (legacy load)"
 fi
+
+# Force-start the while-loop script regardless of load method
+if launchctl kickstart -k "$DOMAIN/$LABEL" 2>/dev/null; then
+    echo "  kickstarted: $LABEL"
+else
+    echo "  WARN: kickstart failed — trying direct launch"
+    nohup bash "$DOTFILES_DIR/launchd/scripts/xlsx-clip-watcher.sh" \
+        >> /tmp/xlsx-clip-watcher.log 2>&1 &
+    echo "  launched directly (PID $!)"
+fi
+
+# Survive logout: crontab @reboot re-kickstarts the registered agent
+CRON_ENTRY="@reboot launchctl kickstart -k $DOMAIN/$LABEL  # xlsx-clip-watcher"
+(crontab -l 2>/dev/null | grep -v "xlsx-clip-watcher" || true; echo "$CRON_ENTRY") | crontab -
+echo "  crontab @reboot entry set"
 
 echo ""
 echo "Log:   tail -f /tmp/xlsx-clip-watcher.log"
 echo "State: $HOME/.local/state/xlsx-clip-watcher/seen.txt"
 echo ""
-echo "Done. Agent polls every 5s — clipboard updates within 5s of a new download."
+echo "Done. Watcher polling every 5s."


### PR DESCRIPTION
Legacy `launchctl load` registers the agent (OnDemand:true) but doesn't start the script. `launchctl kickstart -k` force-starts it regardless of load method. Since the script loops forever (while/sleep 5), launchd never needs to restart it. `crontab @reboot` re-kickstarts after logout/login. Fallback: if kickstart also fails, launch the script directly with nohup.