### PR TITLE
xlsx-clip-watcher: nohup + crontab watchdog, drop launchd scheduling

### DIFF
--- a/launchd/install-xlsx-clip-watcher.sh
+++ b/launchd/install-xlsx-clip-watcher.sh
@@ -1,52 +1,37 @@
 #!/usr/bin/env bash
-# install-xlsx-clip-watcher.sh — installs and loads com.joshuashew.xlsx-clip-watcher
+# install-xlsx-clip-watcher.sh — starts the watcher and makes it persistent
 
 DOTFILES_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")/.." && pwd)"
-TEMPLATE="$DOTFILES_DIR/launchd/agents/com.joshuashew.xlsx-clip-watcher.plist.template"
-PLIST_DIR="$HOME/Library/LaunchAgents"
-PLIST_DEST="$PLIST_DIR/com.joshuashew.xlsx-clip-watcher.plist"
-LABEL="com.joshuashew.xlsx-clip-watcher"
-DOMAIN="gui/$(id -u)"
+SCRIPT="$DOTFILES_DIR/launchd/scripts/xlsx-clip-watcher.sh"
+LOG="/tmp/xlsx-clip-watcher.log"
 
 echo "=== install-xlsx-clip-watcher $(date +%H:%M:%S) ==="
 echo "  dotfiles: $DOTFILES_DIR"
 
-mkdir -p "$PLIST_DIR"
-sed "s|\$HOME|$HOME|g" "$TEMPLATE" > "$PLIST_DEST"
-echo "  plist written: $PLIST_DEST"
-
-chmod +x "$DOTFILES_DIR/launchd/scripts/xlsx-clip-watcher.sh"
+chmod +x "$SCRIPT"
 echo "  script marked executable"
 
-# Stop any running instance
-launchctl bootout "$DOMAIN/$LABEL" 2>/dev/null || launchctl unload "$PLIST_DEST" 2>/dev/null || true
-sleep 1
-
-# Register with launchd (bootstrap preferred, legacy fallback)
-if launchctl bootstrap "$DOMAIN" "$PLIST_DEST" 2>/dev/null; then
-    echo "  registered: $LABEL (bootstrap)"
-else
-    launchctl load "$PLIST_DEST" 2>/dev/null || true
-    echo "  registered: $LABEL (legacy load)"
+# Stop any previous instance
+if pkill -f "xlsx-clip-watcher.sh" 2>/dev/null; then
+    echo "  stopped previous instance"
+    sleep 1
 fi
 
-# Force-start the while-loop script regardless of load method
-if launchctl kickstart -k "$DOMAIN/$LABEL" 2>/dev/null; then
-    echo "  kickstarted: $LABEL"
-else
-    echo "  WARN: kickstart failed — trying direct launch"
-    nohup bash "$DOTFILES_DIR/launchd/scripts/xlsx-clip-watcher.sh" \
-        >> /tmp/xlsx-clip-watcher.log 2>&1 &
-    echo "  launched directly (PID $!)"
-fi
+# Start directly — no launchd scheduling required
+nohup /bin/bash "$SCRIPT" >> "$LOG" 2>&1 &
+WATCHER_PID=$!
+echo "  started: PID $WATCHER_PID"
 
-# Survive logout: crontab @reboot re-kickstarts the registered agent
-CRON_ENTRY="@reboot launchctl kickstart -k $DOMAIN/$LABEL  # xlsx-clip-watcher"
-(crontab -l 2>/dev/null | grep -v "xlsx-clip-watcher" || true; echo "$CRON_ENTRY") | crontab -
-echo "  crontab @reboot entry set"
+# Persist across login: @reboot starts it, watchdog restarts if it crashes
+REBOOT_ENTRY="@reboot /bin/bash $SCRIPT >> $LOG 2>&1 &  # xlsx-clip-watcher"
+WATCHDOG_ENTRY="* * * * * pgrep -qf xlsx-clip-watcher.sh || /bin/bash $SCRIPT >> $LOG 2>&1 &  # xlsx-clip-watcher"
+(crontab -l 2>/dev/null | grep -v "xlsx-clip-watcher" || true
+ echo "$REBOOT_ENTRY"
+ echo "$WATCHDOG_ENTRY") | crontab -
+echo "  crontab: @reboot + 1-min watchdog"
 
 echo ""
-echo "Log:   tail -f /tmp/xlsx-clip-watcher.log"
+echo "Log:   tail -f $LOG"
 echo "State: $HOME/.local/state/xlsx-clip-watcher/seen.txt"
 echo ""
 echo "Done. Watcher polling every 5s."

--- a/launchd/scripts/xlsx-clip-watcher.sh
+++ b/launchd/scripts/xlsx-clip-watcher.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
-# xlsx-clip-watcher — continuous poller, runs via KeepAlive launchd agent
-# Checks ~/Downloads every 5 seconds for new .xlsx < 500KB and runs
-# clip import xlsx if any are new. Tracks by device:inode.
+# xlsx-clip-watcher — polled every 5s via nohup background process
+# Runs clip import xlsx if any new .xlsx < 500KB has appeared since last run.
+# Tracks files by device:inode so a re-downloaded file with the same name
+# counts as new.
 
 export PATH="$HOME/.local/bin:$HOME/bin:$HOME/.dotfiles/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin"
 
@@ -10,6 +11,7 @@ STATE_DIR="$HOME/.local/state/xlsx-clip-watcher"
 SEEN_FILE="$STATE_DIR/seen.txt"
 
 mkdir -p "$STATE_DIR"
+echo "[xlsx-clip-watcher] $(date '+%Y-%m-%d %H:%M:%S') starting up (PID $$)"
 
 while true; do
     new_inodes=()
@@ -28,7 +30,7 @@ while true; do
         if clip import xlsx -d "$DOWNLOADS"; then
             printf '%s\n' "${new_inodes[@]}" >> "$SEEN_FILE"
         else
-            echo "[xlsx-clip-watcher] $(date '+%Y-%m-%d %H:%M:%S') clip exited non-zero — inodes not marked seen"
+            echo "[xlsx-clip-watcher] $(date '+%Y-%m-%d %H:%M:%S') ERROR: clip exited non-zero — inodes not marked seen"
         fi
     fi
 


### PR DESCRIPTION
Drop launchd scheduling entirely. `launchctl bootstrap` fails with error 5; legacy `launchctl load` silently ignores StartInterval/KeepAlive/RunAtLoad; kickstart succeeds but script never starts (unknown reason).

**New approach:** `nohup bash script >> log &` in the installer. Script manages its own poll loop (while/sleep 5). Two crontab entries for persistence: `@reboot` (start after login) + `* * * * *` watchdog (restart if crashed).

Added startup log line so we can confirm the process actually launched.