### PR TITLE
xlsx-clip-watcher: switch to fswatch (FSEvents, no polling)

### DIFF
--- a/launchd/install-xlsx-clip-watcher.sh
+++ b/launchd/install-xlsx-clip-watcher.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# install-xlsx-clip-watcher.sh — starts the watcher and makes it persistent
+# install-xlsx-clip-watcher.sh — installs fswatch, starts watcher, sets up persistence
 
 DOTFILES_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")/.." && pwd)"
 SCRIPT="$DOTFILES_DIR/launchd/scripts/xlsx-clip-watcher.sh"
@@ -8,8 +8,17 @@ LOG="/tmp/xlsx-clip-watcher.log"
 echo "=== install-xlsx-clip-watcher $(date +%H:%M:%S) ==="
 echo "  dotfiles: $DOTFILES_DIR"
 
+# Ensure fswatch is available (uses macOS FSEvents, no polling)
+if ! command -v fswatch &>/dev/null; then
+    echo "  installing fswatch via brew..."
+    if ! brew install fswatch; then
+        echo "  ERROR: brew install fswatch failed — aborting"
+        exit 1
+    fi
+fi
+echo "  fswatch: $(command -v fswatch)"
+
 chmod +x "$SCRIPT"
-echo "  script marked executable"
 
 # Stop any previous instance
 if pkill -f "xlsx-clip-watcher.sh" 2>/dev/null; then
@@ -22,7 +31,7 @@ nohup /bin/bash "$SCRIPT" >> "$LOG" 2>&1 &
 WATCHER_PID=$!
 echo "  started: PID $WATCHER_PID"
 
-# Persist across login: @reboot starts it, watchdog restarts if it crashes
+# Persist across login/restart: @reboot starts it, watchdog restarts on crash
 REBOOT_ENTRY="@reboot /bin/bash $SCRIPT >> $LOG 2>&1 &  # xlsx-clip-watcher"
 WATCHDOG_ENTRY="* * * * * pgrep -qf xlsx-clip-watcher.sh || /bin/bash $SCRIPT >> $LOG 2>&1 &  # xlsx-clip-watcher"
 (crontab -l 2>/dev/null | grep -v "xlsx-clip-watcher" || true
@@ -34,4 +43,4 @@ echo ""
 echo "Log:   tail -f $LOG"
 echo "State: $HOME/.local/state/xlsx-clip-watcher/seen.txt"
 echo ""
-echo "Done. Watcher polling every 5s."
+echo "Done. Watcher active (FSEvents, no polling)."

--- a/launchd/scripts/xlsx-clip-watcher.sh
+++ b/launchd/scripts/xlsx-clip-watcher.sh
@@ -1,8 +1,7 @@
 #!/usr/bin/env bash
-# xlsx-clip-watcher — polled every 5s via nohup background process
-# Runs clip import xlsx if any new .xlsx < 500KB has appeared since last run.
-# Tracks files by device:inode so a re-downloaded file with the same name
-# counts as new.
+# xlsx-clip-watcher — FSEvents-based via fswatch (no polling)
+# Runs clip import xlsx on any new .xlsx < 500KB in ~/Downloads.
+# Tracks files by device:inode so a re-downloaded file counts as new.
 
 export PATH="$HOME/.local/bin:$HOME/bin:$HOME/.dotfiles/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin"
 
@@ -11,28 +10,42 @@ STATE_DIR="$HOME/.local/state/xlsx-clip-watcher"
 SEEN_FILE="$STATE_DIR/seen.txt"
 
 mkdir -p "$STATE_DIR"
-echo "[xlsx-clip-watcher] $(date '+%Y-%m-%d %H:%M:%S') starting up (PID $$)"
 
-while true; do
-    new_inodes=()
+log() { echo "[xlsx-clip-watcher] $(date '+%Y-%m-%d %H:%M:%S') $*"; }
+
+check_and_import() {
+    local new_inodes=()
     while IFS= read -r -d '' file; do
+        [[ -f "$file" ]] || continue
+        local size dev_inode
         size=$(stat -f "%z" "$file" 2>/dev/null) || continue
         [ "$size" -ge 512000 ] && continue
         dev_inode=$(stat -f "%d:%i" "$file" 2>/dev/null) || continue
-        if ! grep -qxF "$dev_inode" "$SEEN_FILE" 2>/dev/null; then
-            echo "[xlsx-clip-watcher] $(date '+%Y-%m-%d %H:%M:%S') new: $(basename "$file") (${size}B inode=$dev_inode)"
-            new_inodes+=("$dev_inode")
-        fi
+        grep -qxF "$dev_inode" "$SEEN_FILE" 2>/dev/null && continue
+        log "new: $(basename "$file") (${size}B inode=$dev_inode)"
+        new_inodes+=("$dev_inode")
     done < <(find "$DOWNLOADS" -maxdepth 1 -name "*.xlsx" -print0 2>/dev/null)
 
     if [ "${#new_inodes[@]}" -gt 0 ]; then
-        echo "[xlsx-clip-watcher] $(date '+%Y-%m-%d %H:%M:%S') running: clip import xlsx -d $DOWNLOADS"
+        log "running: clip import xlsx -d $DOWNLOADS"
         if clip import xlsx -d "$DOWNLOADS"; then
             printf '%s\n' "${new_inodes[@]}" >> "$SEEN_FILE"
         else
-            echo "[xlsx-clip-watcher] $(date '+%Y-%m-%d %H:%M:%S') ERROR: clip exited non-zero — inodes not marked seen"
+            log "ERROR: clip exited non-zero — inodes not marked seen"
         fi
     fi
+}
 
-    sleep 5
+log "starting up (PID $$)"
+
+# Startup scan: catch files downloaded while watcher was down
+check_and_import
+log "startup scan complete, entering fswatch loop"
+
+# FSEvents watch — kernel notifies on .xlsx events, zero polling
+fswatch -0 -e ".*" -i ".*\\.xlsx$" "$DOWNLOADS" | \
+while IFS= read -r -d '' _event; do
+    check_and_import
 done
+
+log "fswatch exited unexpectedly (will be restarted by watchdog)"


### PR DESCRIPTION
Switch the watcher from a `sleep 5` polling loop to `fswatch`, which uses macOS FSEvents (kernel-level notification). No polling — detection is event-driven and sub-second.

## Changes

**`launchd/scripts/xlsx-clip-watcher.sh`**
- Replace `while true; do ... sleep 5; done` with `fswatch -0 -e '.*' -i '.*\.xlsx$' ~/Downloads | while read`
- Extract scan logic into `check_and_import()` function called on each fswatch event
- Add startup scan at launch to catch files downloaded while watcher was down (crash gap, restart gap)
- Exits with log message if fswatch itself dies (cron watchdog restarts within 1 min)

**`launchd/install-xlsx-clip-watcher.sh`**
- Add `command -v fswatch` check; installs via `brew install fswatch` if missing
- Prints fswatch path for diagnostics
- Persistence unchanged: nohup + `@reboot` + 1-min watchdog crontab

## Persistence coverage
| Scenario | Handled by |
|---|---|
| Mac sleep/wake | nohup process survives sleep |
| Restart / shutdown | @reboot crontab |
| Crash or fswatch exit | 1-min watchdog crontab |
| Files downloaded while down | startup scan on watcher launch |
