### PR TITLE
xlsx-clip-watcher: move log to ~/.local/state (accessible via filesystem module)

### DIFF
--- a/launchd/install-xlsx-clip-watcher.sh
+++ b/launchd/install-xlsx-clip-watcher.sh
@@ -3,7 +3,7 @@
 
 DOTFILES_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")/.." && pwd)"
 SCRIPT="$DOTFILES_DIR/launchd/scripts/xlsx-clip-watcher.sh"
-LOG="/tmp/xlsx-clip-watcher.log"
+LOG="$HOME/.local/state/xlsx-clip-watcher/watcher.log"
 
 echo "=== install-xlsx-clip-watcher $(date +%H:%M:%S) ==="
 echo "  dotfiles: $DOTFILES_DIR"


### PR DESCRIPTION
Move LOG from `/tmp/xlsx-clip-watcher.log` to `~/.local/state/xlsx-clip-watcher/watcher.log` so the filesystem credential-proxy module can read it from CCotw sessions. The `/tmp/` path is outside home and blocked by the filesystem module's security boundary.