### PR TITLE
xlsx-clip-watcher: auto-deploy via GitHub polling + autonomous log access

### DIFF
--- a/launchd/install-xlsx-clip-watcher.sh
+++ b/launchd/install-xlsx-clip-watcher.sh
@@ -43,4 +43,18 @@ echo ""
 echo "Log:   tail -f $LOG"
 echo "State: $HOME/.local/state/xlsx-clip-watcher/seen.txt"
 echo ""
-echo "Done. Watcher active (FSEvents, no polling)."
+echo "Done. Watcher active (FSEvents, no polling).
+
+# --- auto-updater: polls GitHub every 5min and reinstalls on new commits ---
+AUTO_UPDATER="$DOTFILES_DIR/launchd/scripts/dotfiles-auto-updater.sh"
+AUTO_LOG="$HOME/.local/state/xlsx-clip-watcher/auto-updater.log"
+chmod +x "$AUTO_UPDATER"
+pkill -f "dotfiles-auto-updater.sh" 2>/dev/null && sleep 1
+nohup /bin/bash "$AUTO_UPDATER" >> "$AUTO_LOG" 2>&1 &
+echo "  auto-updater: PID $!"
+AU_REBOOT="@reboot /bin/bash $AUTO_UPDATER >> $AUTO_LOG 2>&1 &  # xlsx-clip-watcher-updater"
+AU_WATCHDOG="* * * * * pgrep -qf dotfiles-auto-updater.sh || /bin/bash $AUTO_UPDATER >> $AUTO_LOG 2>&1 &  # xlsx-clip-watcher-updater"
+(crontab -l 2>/dev/null | grep -v "xlsx-clip-watcher-updater" || true
+ echo "$AU_REBOOT"
+ echo "$AU_WATCHDOG") | crontab -
+echo "  auto-updater crontab: @reboot + 1-min watchdog""

--- a/launchd/scripts/dotfiles-auto-updater.sh
+++ b/launchd/scripts/dotfiles-auto-updater.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# dotfiles-auto-updater — polls for new dotfiles commits and reinstalls on change.
+# Detects updates every 5 minutes; runs install-xlsx-clip-watcher.sh on change.
+
+export PATH="$HOME/.local/bin:$HOME/bin:$HOME/.dotfiles/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin"
+
+DOTFILES="$HOME/.dotfiles"
+STATE_DIR="$HOME/.local/state/xlsx-clip-watcher"
+LOCK_FILE="$STATE_DIR/auto-updater.lock"
+INTERVAL=300
+
+mkdir -p "$STATE_DIR"
+log() { echo "[dotfiles-auto-updater] $(date '+%Y-%m-%d %H:%M:%S') $*"; }
+
+exec 9>"$LOCK_FILE"
+if ! flock -n 9; then
+    log "another instance already running, exiting"
+    exit 0
+fi
+echo $$ > "$LOCK_FILE"
+
+log "starting (PID $$)"
+
+while true; do
+    BEFORE=$(git -C "$DOTFILES" rev-parse HEAD 2>/dev/null)
+    if git -C "$DOTFILES" fetch origin main --quiet 2>/dev/null; then
+        AFTER=$(git -C "$DOTFILES" rev-parse origin/main 2>/dev/null)
+        if [ "$BEFORE" != "$AFTER" ]; then
+            log "new commits: ${BEFORE:0:8} -> ${AFTER:0:8}, updating"
+            git -C "$DOTFILES" pull origin main 2>&1
+            bash "$DOTFILES/launchd/install-xlsx-clip-watcher.sh" 2>&1
+            log "update complete"
+        fi
+    else
+        log "git fetch failed (network or auth), skipping this cycle"
+    fi
+    sleep "$INTERVAL"
+done


### PR DESCRIPTION
Two changes to enable full CCotw autonomous control:

**1. `dotfiles-auto-updater.sh` (new)**
Background process that fetches dotfiles/main every 5 minutes. If new commits are found, it runs `git pull + install-xlsx-clip-watcher.sh` automatically. Uses flock for single-instance enforcement. CCotw can push to dotfiles and the change deploys without Joshua running a command.

**2. `install-xlsx-clip-watcher.sh` (updated)**
Also starts/restarts the auto-updater. Adds `@reboot` + 1-min watchdog crontab entries for the auto-updater. Both the watcher and auto-updater are now self-healing across reboots and crashes.

**Log locations (all in `~/.local/state/xlsx-clip-watcher/`, readable by filesystem module):**
- `watcher.log` — xlsx detection events (moved from /tmp in PR #21)
- `auto-updater.log` — deploy events (new)

**CCotw autonomous workflow after bootstrap:**
1. Push change to dotfiles main
2. Auto-updater detects within 5 minutes, pulls, reinstalls
3. Read `watcher.log` and `auto-updater.log` via filesystem module to verify
