### PR TITLE
xlsx-clip-watcher: fix flock leak + installer syntax error

### DIFF
--- a/launchd/install-xlsx-clip-watcher.sh
+++ b/launchd/install-xlsx-clip-watcher.sh
@@ -1,60 +1,57 @@
 #!/usr/bin/env bash
-# install-xlsx-clip-watcher.sh — installs fswatch, starts watcher, sets up persistence
+# install-xlsx-clip-watcher.sh — starts watcher + auto-updater, sets up persistence
 
 DOTFILES_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")/.." && pwd)"
 SCRIPT="$DOTFILES_DIR/launchd/scripts/xlsx-clip-watcher.sh"
-LOG="$HOME/.local/state/xlsx-clip-watcher/watcher.log"
+AUTO_UPDATER="$DOTFILES_DIR/launchd/scripts/dotfiles-auto-updater.sh"
+STATE_DIR="$HOME/.local/state/xlsx-clip-watcher"
+LOG="$STATE_DIR/watcher.log"
+AUTO_LOG="$STATE_DIR/auto-updater.log"
+
+mkdir -p "$STATE_DIR"
 
 echo "=== install-xlsx-clip-watcher $(date +%H:%M:%S) ==="
 echo "  dotfiles: $DOTFILES_DIR"
 
-# Ensure fswatch is available (uses macOS FSEvents, no polling)
 if ! command -v fswatch &>/dev/null; then
     echo "  installing fswatch via brew..."
-    if ! brew install fswatch; then
-        echo "  ERROR: brew install fswatch failed — aborting"
-        exit 1
-    fi
+    brew install fswatch || { echo "  ERROR: brew install fswatch failed"; exit 1; }
 fi
 echo "  fswatch: $(command -v fswatch)"
 
-chmod +x "$SCRIPT"
+chmod +x "$SCRIPT" "$AUTO_UPDATER"
 
-# Stop any previous instance
-if pkill -f "xlsx-clip-watcher.sh" 2>/dev/null; then
-    echo "  stopped previous instance"
-    sleep 1
-fi
+# Stop watcher: kill the named script AND fswatch (child process that holds
+# the flock fd via the pipeline; pkill on script name alone leaves fswatch
+# as an orphan keeping the lock).
+pkill -f "xlsx-clip-watcher.sh" 2>/dev/null && echo "  watcher: stopped"
+pkill -f "fswatch.*Downloads" 2>/dev/null && echo "  fswatch: stopped"
+sleep 1
 
-# Start directly — no launchd scheduling required
 nohup /bin/bash "$SCRIPT" >> "$LOG" 2>&1 &
-WATCHER_PID=$!
-echo "  started: PID $WATCHER_PID"
+echo "  watcher: started PID $!"
 
-# Persist across login/restart: @reboot starts it, watchdog restarts on crash
-REBOOT_ENTRY="@reboot /bin/bash $SCRIPT >> $LOG 2>&1 &  # xlsx-clip-watcher"
-WATCHDOG_ENTRY="* * * * * pgrep -qf xlsx-clip-watcher.sh || /bin/bash $SCRIPT >> $LOG 2>&1 &  # xlsx-clip-watcher"
-(crontab -l 2>/dev/null | grep -v "xlsx-clip-watcher" || true
- echo "$REBOOT_ENTRY"
- echo "$WATCHDOG_ENTRY") | crontab -
-echo "  crontab: @reboot + 1-min watchdog"
+pkill -f "dotfiles-auto-updater.sh" 2>/dev/null && echo "  auto-updater: stopped"
+sleep 1
 
-echo ""
-echo "Log:   tail -f $LOG"
-echo "State: $HOME/.local/state/xlsx-clip-watcher/seen.txt"
-echo ""
-echo "Done. Watcher active (FSEvents, no polling).
-
-# --- auto-updater: polls GitHub every 5min and reinstalls on new commits ---
-AUTO_UPDATER="$DOTFILES_DIR/launchd/scripts/dotfiles-auto-updater.sh"
-AUTO_LOG="$HOME/.local/state/xlsx-clip-watcher/auto-updater.log"
-chmod +x "$AUTO_UPDATER"
-pkill -f "dotfiles-auto-updater.sh" 2>/dev/null && sleep 1
 nohup /bin/bash "$AUTO_UPDATER" >> "$AUTO_LOG" 2>&1 &
-echo "  auto-updater: PID $!"
-AU_REBOOT="@reboot /bin/bash $AUTO_UPDATER >> $AUTO_LOG 2>&1 &  # xlsx-clip-watcher-updater"
-AU_WATCHDOG="* * * * * pgrep -qf dotfiles-auto-updater.sh || /bin/bash $AUTO_UPDATER >> $AUTO_LOG 2>&1 &  # xlsx-clip-watcher-updater"
-(crontab -l 2>/dev/null | grep -v "xlsx-clip-watcher-updater" || true
- echo "$AU_REBOOT"
- echo "$AU_WATCHDOG") | crontab -
-echo "  auto-updater crontab: @reboot + 1-min watchdog""
+echo "  auto-updater: started PID $!"
+
+REBOOT_W="@reboot /bin/bash $SCRIPT >> $LOG 2>&1 &  # xlsx-clip-watcher"
+WATCHDOG_W="* * * * * pgrep -qf xlsx-clip-watcher.sh || /bin/bash $SCRIPT >> $LOG 2>&1 &  # xlsx-clip-watcher"
+REBOOT_A="@reboot /bin/bash $AUTO_UPDATER >> $AUTO_LOG 2>&1 &  # xlsx-clip-watcher-updater"
+WATCHDOG_A="* * * * * pgrep -qf dotfiles-auto-updater.sh || /bin/bash $AUTO_UPDATER >> $AUTO_LOG 2>&1 &  # xlsx-clip-watcher-updater"
+
+(crontab -l 2>/dev/null | grep -v "xlsx-clip-watcher" || true
+ echo "$REBOOT_W"
+ echo "$WATCHDOG_W"
+ echo "$REBOOT_A"
+ echo "$WATCHDOG_A") | crontab -
+echo "  crontab: @reboot + 1-min watchdog (watcher + auto-updater)"
+
+echo ""
+echo "Logs:"
+echo "  watcher:      tail -f $LOG"
+echo "  auto-updater: tail -f $AUTO_LOG"
+echo "State: $STATE_DIR/seen.txt"
+echo "Done."

--- a/launchd/scripts/dotfiles-auto-updater.sh
+++ b/launchd/scripts/dotfiles-auto-updater.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 # dotfiles-auto-updater — polls for new dotfiles commits and reinstalls on change.
-# Detects updates every 5 minutes; runs install-xlsx-clip-watcher.sh on change.
 
 export PATH="$HOME/.local/bin:$HOME/bin:$HOME/.dotfiles/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin"
 
@@ -12,12 +11,13 @@ INTERVAL=300
 mkdir -p "$STATE_DIR"
 log() { echo "[dotfiles-auto-updater] $(date '+%Y-%m-%d %H:%M:%S') $*"; }
 
+trap 'kill 0 2>/dev/null; exit 0' SIGTERM SIGINT
+
 exec 9>"$LOCK_FILE"
 if ! flock -n 9; then
     log "another instance already running, exiting"
     exit 0
 fi
-echo $$ > "$LOCK_FILE"
 
 log "starting (PID $$)"
 
@@ -32,7 +32,7 @@ while true; do
             log "update complete"
         fi
     else
-        log "git fetch failed (network or auth), skipping this cycle"
+        log "git fetch failed (network or auth), skipping"
     fi
     sleep "$INTERVAL"
 done

--- a/launchd/scripts/xlsx-clip-watcher.sh
+++ b/launchd/scripts/xlsx-clip-watcher.sh
@@ -14,13 +14,16 @@ mkdir -p "$STATE_DIR"
 
 log() { echo "[xlsx-clip-watcher] $(date '+%Y-%m-%d %H:%M:%S') $*"; }
 
-# Ensure only one instance runs; flock releases automatically on exit/crash
+# Kill entire process group on SIGTERM so fswatch and the while-loop subshell
+# (which inherit the flock fd) are cleaned up — otherwise pkill leaves orphans
+# that hold the lock and cause every restart to immediately exit.
+trap 'kill 0 2>/dev/null; exit 0' SIGTERM SIGINT
+
 exec 9>"$LOCK_FILE"
 if ! flock -n 9; then
-    log "another instance already running (PID $(cat "$LOCK_FILE" 2>/dev/null)), exiting"
+    log "another instance already running, exiting"
     exit 0
 fi
-echo $$ > "$LOCK_FILE"
 
 check_and_import() {
     local new_inodes=()
@@ -46,12 +49,9 @@ check_and_import() {
 }
 
 log "starting up (PID $$)"
-
-# Startup scan: catch files downloaded while watcher was down
 check_and_import
 log "startup scan complete, entering fswatch loop"
 
-# FSEvents watch — kernel notifies on .xlsx events, zero polling
 fswatch -0 -e ".*" -i ".*\\.xlsx$" "$DOWNLOADS" | \
 while IFS= read -r -d '' _event; do
     check_and_import


### PR DESCRIPTION
Fix flock orphan leak (SIGTERM trap kills process group) and installer syntax error from string-replacement approach. Also kill fswatch explicitly on install to clear any existing orphans.