### PR TITLE
dotfiles-auto-updater: fix commit detection loop + self-kill

### DIFF
--- a/launchd/install-xlsx-clip-watcher.sh
+++ b/launchd/install-xlsx-clip-watcher.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 # install-xlsx-clip-watcher.sh — starts watcher + auto-updater, sets up persistence
+# When XLSX_UPDATER_RUN=1 (called from dotfiles-auto-updater), skips auto-updater
+# management to avoid the updater killing itself mid-install.
 
 DOTFILES_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")/.." && pwd)"
 SCRIPT="$DOTFILES_DIR/launchd/scripts/xlsx-clip-watcher.sh"
@@ -31,23 +33,27 @@ sleep 1
 nohup /bin/bash "$SCRIPT" >> "$LOG" 2>&1 &
 echo "  watcher: started PID $!"
 
-pkill -f "dotfiles-auto-updater.sh" 2>/dev/null && echo "  auto-updater: stopped"
-sleep 1
-
-nohup /bin/bash "$AUTO_UPDATER" >> "$AUTO_LOG" 2>&1 &
-echo "  auto-updater: started PID $!"
+# Auto-updater management: skipped when called from the auto-updater itself
+# (XLSX_UPDATER_RUN=1) to avoid the updater killing itself via its SIGTERM trap.
+if [ "${XLSX_UPDATER_RUN:-}" != "1" ]; then
+    pkill -f "dotfiles-auto-updater.sh" 2>/dev/null && echo "  auto-updater: stopped"
+    sleep 1
+    nohup /bin/bash "$AUTO_UPDATER" >> "$AUTO_LOG" 2>&1 &
+    echo "  auto-updater: started PID $!"
+fi
 
 REBOOT_W="@reboot /bin/bash $SCRIPT >> $LOG 2>&1 &  # xlsx-clip-watcher"
 WATCHDOG_W="* * * * * pgrep -qf xlsx-clip-watcher.sh || /bin/bash $SCRIPT >> $LOG 2>&1 &  # xlsx-clip-watcher"
 REBOOT_A="@reboot /bin/bash $AUTO_UPDATER >> $AUTO_LOG 2>&1 &  # xlsx-clip-watcher-updater"
 WATCHDOG_A="* * * * * pgrep -qf dotfiles-auto-updater.sh || /bin/bash $AUTO_UPDATER >> $AUTO_LOG 2>&1 &  # xlsx-clip-watcher-updater"
 
+# crontab write may fail in non-interactive contexts (macOS permission model).
+# Non-fatal: crontab from the initial interactive install persists.
 (crontab -l 2>/dev/null | grep -v "xlsx-clip-watcher" || true
  echo "$REBOOT_W"
  echo "$WATCHDOG_W"
  echo "$REBOOT_A"
- echo "$WATCHDOG_A") | crontab -
-echo "  crontab: @reboot + 1-min watchdog (watcher + auto-updater)"
+ echo "$WATCHDOG_A") | crontab - 2>/dev/null && echo "  crontab: updated" || echo "  crontab: skipped (non-interactive; prior entries still active)"
 
 echo ""
 echo "Logs:"

--- a/launchd/scripts/dotfiles-auto-updater.sh
+++ b/launchd/scripts/dotfiles-auto-updater.sh
@@ -22,14 +22,19 @@ fi
 log "starting (PID $$)"
 
 while true; do
-    BEFORE=$(git -C "$DOTFILES" rev-parse HEAD 2>/dev/null)
     if git -C "$DOTFILES" fetch origin main --quiet 2>/dev/null; then
-        AFTER=$(git -C "$DOTFILES" rev-parse origin/main 2>/dev/null)
-        if [ "$BEFORE" != "$AFTER" ]; then
-            log "new commits: ${BEFORE:0:8} -> ${AFTER:0:8}, updating"
+        # Count commits in origin/main not yet in HEAD. Using rev-list rather
+        # than comparing SHAs directly handles merge-pull (where HEAD is a merge
+        # commit with a different SHA than origin/main but already contains it).
+        BEHIND=$(git -C "$DOTFILES" rev-list HEAD..origin/main --count 2>/dev/null || echo 0)
+        if [ "${BEHIND:-0}" -gt 0 ]; then
+            log "$BEHIND new commit(s) on origin/main, updating"
             git -C "$DOTFILES" pull origin main 2>&1
-            bash "$DOTFILES/launchd/install-xlsx-clip-watcher.sh" 2>&1
-            log "update complete"
+            # XLSX_UPDATER_RUN=1 tells the installer to skip auto-updater
+            # management (avoids killing itself mid-install via the trap).
+            XLSX_UPDATER_RUN=1 bash "$DOTFILES/launchd/install-xlsx-clip-watcher.sh" 2>&1
+            log "update complete — exiting so cron restarts with new code"
+            exit 0
         fi
     else
         log "git fetch failed (network or auth), skipping"


### PR DESCRIPTION
**Bug 1 — infinite loop:** Comparing HEAD SHA vs origin/main SHA fails after a merge-pull (HEAD becomes a merge commit with a different SHA than origin/main, even though it already contains all commits). Fix: `git rev-list HEAD..origin/main --count` — returns 0 when HEAD already contains origin/main.

**Bug 2 — self-kill:** Auto-updater called `bash install-xlsx-clip-watcher.sh` which pkill'd the auto-updater itself mid-run. The SIGTERM trap's `kill 0` killed the install script subprocess too, aborting crontab writes. Fix: `XLSX_UPDATER_RUN=1` env flag — installer skips auto-updater management when called from the updater. Auto-updater exits cleanly after install (cron watchdog restarts it with new code).

**Bug 3 — crontab failure non-fatal:** `crontab -` fails silently in non-interactive contexts. Made failure print a warning instead of breaking the install.
