### PR TITLE
auto-updater: fix git pull blocked by chmod mode change

### DIFF
--- a/launchd/install-xlsx-clip-watcher.sh
+++ b/launchd/install-xlsx-clip-watcher.sh
@@ -34,7 +34,7 @@ nohup /bin/bash "$SCRIPT" >> "$LOG" 2>&1 &
 echo "  watcher: started PID $!"
 
 # Auto-updater management: skipped when called from the auto-updater itself
-# (XLSX_UPDATER_RUN=1) to avoid the updater killing itself via its SIGTERM trap.
+# (XLSX_UPDATER_RUN=1) to avoid the updater killing itself mid-install via the trap.
 if [ "${XLSX_UPDATER_RUN:-}" != "1" ]; then
     pkill -f "dotfiles-auto-updater.sh" 2>/dev/null && echo "  auto-updater: stopped"
     sleep 1

--- a/launchd/scripts/dotfiles-auto-updater.sh
+++ b/launchd/scripts/dotfiles-auto-updater.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 # dotfiles-auto-updater — polls for new dotfiles commits and reinstalls on change.
-
 export PATH="$HOME/.local/bin:$HOME/bin:$HOME/.dotfiles/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin"
 
 DOTFILES="$HOME/.dotfiles"
@@ -29,12 +28,20 @@ while true; do
         BEHIND=$(git -C "$DOTFILES" rev-list HEAD..origin/main --count 2>/dev/null || echo 0)
         if [ "${BEHIND:-0}" -gt 0 ]; then
             log "$BEHIND new commit(s) on origin/main, updating"
-            git -C "$DOTFILES" pull origin main 2>&1
-            # XLSX_UPDATER_RUN=1 tells the installer to skip auto-updater
-            # management (avoids killing itself mid-install via the trap).
-            XLSX_UPDATER_RUN=1 bash "$DOTFILES/launchd/install-xlsx-clip-watcher.sh" 2>&1
-            log "update complete — exiting so cron restarts with new code"
-            exit 0
+            # Reset working tree before pull — installer's chmod +x sets the execute
+            # bit on this script (100644 → 100755). With core.filemode=true (macOS
+            # default), git treats the mode change as a local modification and blocks
+            # fast-forward pulls. Reset clears this before every pull.
+            git -C "$DOTFILES" reset --hard HEAD 2>/dev/null || true
+            if git -C "$DOTFILES" pull origin main 2>&1; then
+                # XLSX_UPDATER_RUN=1 tells the installer to skip auto-updater
+                # management (avoids killing itself mid-install via the trap).
+                XLSX_UPDATER_RUN=1 bash "$DOTFILES/launchd/install-xlsx-clip-watcher.sh" 2>&1
+                log "update complete — exiting so cron restarts with new code"
+                exit 0
+            else
+                log "pull failed — will retry next cycle"
+            fi
         fi
     else
         log "git fetch failed (network or auth), skipping"


### PR DESCRIPTION
## Root cause

The installer's `chmod +x` sets `dotfiles-auto-updater.sh` to mode 100755 on disk. Git has it committed as 100644. With `core.filemode=true` (macOS default), git treats this as a local modification. Any `git pull` that needs to update that file fails with:

```
error: Your local changes to the following files would be overwritten by merge:
	launchd/scripts/dotfiles-auto-updater.sh
```

This blocked PR #24's changes from being applied, causing the auto-updater to run stale code and eventually stop entirely.

## Fixes

1. **`git reset --hard HEAD` before every pull** — clears the mode change so pulls always succeed
2. **Commit auto-updater.sh as mode 100755** — mode matches post-chmod disk state; `chmod +x` becomes idempotent from git's perspective
3. **Check pull exit code** — skip installer and retry next cycle if pull fails (prevents cascading failures)
4. **`rev-list --count` for change detection** — replaces SHA comparison that misidentified merge-pulls as needing updates (from PR #24)
5. **`XLSX_UPDATER_RUN=1`** — prevents auto-updater from killing itself when calling installer (from PR #24)
6. **`exit 0` after update** — ensures cron restarts with freshly-pulled code (from PR #24)
7. **Installer: `XLSX_UPDATER_RUN` guard** — conditional auto-updater restart (from PR #24)
8. **Non-fatal crontab** — crontab write fails in non-interactive contexts; log and continue (from PR #24)