### PR TITLE
xlsx-clip-watcher: ScheduleAtAGlance filter + trash after import

### DIFF
--- a/launchd/install-xlsx-clip-watcher.sh
+++ b/launchd/install-xlsx-clip-watcher.sh
@@ -1,14 +1,11 @@
 #!/usr/bin/env bash
-# install-xlsx-clip-watcher.sh — starts watcher + auto-updater, sets up persistence
-# When XLSX_UPDATER_RUN=1 (called from dotfiles-auto-updater), skips auto-updater
-# management to avoid the updater killing itself mid-install.
+# install-xlsx-clip-watcher.sh — starts watcher, sets up cron persistence.
+# Deploy via: POST /proxy/dashboard/admin/deploy/dotfiles
 
 DOTFILES_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")/.." && pwd)"
 SCRIPT="$DOTFILES_DIR/launchd/scripts/xlsx-clip-watcher.sh"
-AUTO_UPDATER="$DOTFILES_DIR/launchd/scripts/dotfiles-auto-updater.sh"
 STATE_DIR="$HOME/.local/state/xlsx-clip-watcher"
 LOG="$STATE_DIR/watcher.log"
-AUTO_LOG="$STATE_DIR/auto-updater.log"
 
 mkdir -p "$STATE_DIR"
 
@@ -21,11 +18,9 @@ if ! command -v fswatch &>/dev/null; then
 fi
 echo "  fswatch: $(command -v fswatch)"
 
-chmod +x "$SCRIPT" "$AUTO_UPDATER"
+chmod +x "$SCRIPT"
 
-# Stop watcher: kill the named script AND fswatch (child process that holds
-# the flock fd via the pipeline; pkill on script name alone leaves fswatch
-# as an orphan keeping the lock).
+# Stop any running instance (and its fswatch child) before restarting.
 pkill -f "xlsx-clip-watcher.sh" 2>/dev/null && echo "  watcher: stopped"
 pkill -f "fswatch.*Downloads" 2>/dev/null && echo "  fswatch: stopped"
 sleep 1
@@ -33,31 +28,16 @@ sleep 1
 nohup /bin/bash "$SCRIPT" >> "$LOG" 2>&1 &
 echo "  watcher: started PID $!"
 
-# Auto-updater management: skipped when called from the auto-updater itself
-# (XLSX_UPDATER_RUN=1) to avoid the updater killing itself mid-install via the trap.
-if [ "${XLSX_UPDATER_RUN:-}" != "1" ]; then
-    pkill -f "dotfiles-auto-updater.sh" 2>/dev/null && echo "  auto-updater: stopped"
-    sleep 1
-    nohup /bin/bash "$AUTO_UPDATER" >> "$AUTO_LOG" 2>&1 &
-    echo "  auto-updater: started PID $!"
-fi
-
 REBOOT_W="@reboot /bin/bash $SCRIPT >> $LOG 2>&1 &  # xlsx-clip-watcher"
 WATCHDOG_W="* * * * * pgrep -qf xlsx-clip-watcher.sh || /bin/bash $SCRIPT >> $LOG 2>&1 &  # xlsx-clip-watcher"
-REBOOT_A="@reboot /bin/bash $AUTO_UPDATER >> $AUTO_LOG 2>&1 &  # xlsx-clip-watcher-updater"
-WATCHDOG_A="* * * * * pgrep -qf dotfiles-auto-updater.sh || /bin/bash $AUTO_UPDATER >> $AUTO_LOG 2>&1 &  # xlsx-clip-watcher-updater"
 
 # crontab write may fail in non-interactive contexts (macOS permission model).
 # Non-fatal: crontab from the initial interactive install persists.
 (crontab -l 2>/dev/null | grep -v "xlsx-clip-watcher" || true
  echo "$REBOOT_W"
- echo "$WATCHDOG_W"
- echo "$REBOOT_A"
- echo "$WATCHDOG_A") | crontab - 2>/dev/null && echo "  crontab: updated" || echo "  crontab: skipped (non-interactive; prior entries still active)"
+ echo "$WATCHDOG_W") | crontab - 2>/dev/null && echo "  crontab: updated" || echo "  crontab: skipped (non-interactive; prior entries still active)"
 
 echo ""
-echo "Logs:"
-echo "  watcher:      tail -f $LOG"
-echo "  auto-updater: tail -f $AUTO_LOG"
+echo "Log: tail -f $LOG"
 echo "State: $STATE_DIR/seen.txt"
 echo "Done."

--- a/launchd/scripts/xlsx-clip-watcher.sh
+++ b/launchd/scripts/xlsx-clip-watcher.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # xlsx-clip-watcher — FSEvents-based via fswatch (no polling)
-# Runs clip import xlsx on any new .xlsx < 500KB in ~/Downloads.
+# Only processes .xlsx files in ~/Downloads whose name starts with "ScheduleAtAGlance".
+# On confirmed clip import, moves the file to Trash (not deleted).
 # Tracks files by device:inode so a re-downloaded file counts as new.
 
 export PATH="$HOME/.local/bin:$HOME/bin:$HOME/.dotfiles/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin"
@@ -27,23 +28,35 @@ fi
 
 check_and_import() {
     local new_inodes=()
+    local new_files=()
     while IFS= read -r -d '' file; do
         [[ -f "$file" ]] || continue
-        local size dev_inode
-        size=$(stat -f "%z" "$file" 2>/dev/null) || continue
-        [ "$size" -ge 512000 ] && continue
+        # Only process files starting with "ScheduleAtAGlance"
+        [[ "$(basename "$file")" == ScheduleAtAGlance* ]] || continue
+        local dev_inode
         dev_inode=$(stat -f "%d:%i" "$file" 2>/dev/null) || continue
         grep -qxF "$dev_inode" "$SEEN_FILE" 2>/dev/null && continue
-        log "new: $(basename "$file") (${size}B inode=$dev_inode)"
+        log "new: $(basename "$file") (inode=$dev_inode)"
         new_inodes+=("$dev_inode")
+        new_files+=("$file")
     done < <(find "$DOWNLOADS" -maxdepth 1 -name "*.xlsx" -print0 2>/dev/null)
 
-    if [ "${#new_inodes[@]}" -gt 0 ]; then
+    if [ "${#new_files[@]}" -gt 0 ]; then
         log "running: clip import xlsx -d $DOWNLOADS"
         if clip import xlsx -d "$DOWNLOADS"; then
             printf '%s\n' "${new_inodes[@]}" >> "$SEEN_FILE"
+            # Move confirmed files to Trash (osascript primary, ~/.Trash fallback)
+            for f in "${new_files[@]}"; do
+                if osascript -e "tell application \"Finder\" to delete POSIX file \"$f\"" 2>/dev/null; then
+                    log "trashed: $(basename "$f")"
+                elif mv "$f" "$HOME/.Trash/" 2>/dev/null; then
+                    log "trashed (fallback): $(basename "$f")"
+                else
+                    log "WARNING: could not trash $f"
+                fi
+            done
         else
-            log "ERROR: clip exited non-zero — inodes not marked seen"
+            log "ERROR: clip exited non-zero — inodes not marked seen, files not trashed"
         fi
     fi
 }


### PR DESCRIPTION
## Summary

- **Filename filter**: only process `.xlsx` files starting with `ScheduleAtAGlance` (no size limit)
- **Trash after import**: on confirmed `clip import xlsx`, moves the file to Trash via `osascript` (fallback to `~/.Trash` mv)
- **Simplified installer**: removed all `dotfiles-auto-updater.sh` management — deploy is now via credential-proxy dashboard `local-script` type

## Watcher changes (`xlsx-clip-watcher.sh`)

- Removed 500KB size limit
- Added `[[ $(basename "$file") == ScheduleAtAGlance* ]]` guard
- `check_and_import()` now tracks both `new_inodes[]` (dedup) and `new_files[]` (for trash)
- After successful `clip import xlsx`, each file in `new_files` is moved to Trash

## Installer changes (`install-xlsx-clip-watcher.sh`)

- Removed `AUTO_UPDATER` variable and all auto-updater start/stop/crontab management
- Removed `XLSX_UPDATER_RUN` guard (no longer needed)
- Crontab now only writes `xlsx-clip-watcher` entries (not updater entries)