### PR TITLE
xlsx-clip-watcher: replace fswatch daemon with launchd WatchPaths

### DIFF
--- a/launchd/agents/com.joshuashew.xlsx-clip-watcher.plist.template
+++ b/launchd/agents/com.joshuashew.xlsx-clip-watcher.plist.template
@@ -7,15 +7,23 @@
     <key>ProgramArguments</key>
     <array>
         <string>/bin/bash</string>
-        <string>$HOME/.dotfiles/launchd/scripts/xlsx-clip-watcher.sh</string>
+        <string>DOTFILES_DIR/launchd/scripts/xlsx-clip-watcher.sh</string>
     </array>
-    <key>KeepAlive</key>
-    <true/>
+    <!-- WatchPaths: launchd watches ~/Downloads natively; no fswatch needed -->
+    <key>WatchPaths</key>
+    <array>
+        <string>HOME_DIR/Downloads</string>
+    </array>
+    <!-- Run once at load to catch any file that landed before the agent started -->
     <key>RunAtLoad</key>
     <true/>
+    <!-- Throttle: don't re-trigger more than once per 5 seconds -->
+    <key>ThrottleInterval</key>
+    <integer>5</integer>
+    <!-- Log to state dir (created by install script before plist is loaded) -->
     <key>StandardOutPath</key>
-    <string>/tmp/xlsx-clip-watcher.log</string>
+    <string>HOME_DIR/.local/state/xlsx-clip-watcher/launchd.log</string>
     <key>StandardErrorPath</key>
-    <string>/tmp/xlsx-clip-watcher.log</string>
+    <string>HOME_DIR/.local/state/xlsx-clip-watcher/launchd.log</string>
 </dict>
 </plist>

--- a/launchd/install-xlsx-clip-watcher.sh
+++ b/launchd/install-xlsx-clip-watcher.sh
@@ -1,47 +1,61 @@
 #!/usr/bin/env bash
-# install-xlsx-clip-watcher.sh — starts watcher, sets up cron persistence.
-# Deploy via: POST /proxy/dashboard/admin/deploy/dotfiles
+# install-xlsx-clip-watcher.sh — idempotent install/reload of the watcher.
+# Run after pulling dotfiles updates: bash ~/.dotfiles/launchd/install-xlsx-clip-watcher.sh
+
+set -euo pipefail
 
 DOTFILES_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")/.." && pwd)"
-SCRIPT="$DOTFILES_DIR/launchd/scripts/xlsx-clip-watcher.sh"
+TEMPLATE="$DOTFILES_DIR/launchd/agents/com.joshuashew.xlsx-clip-watcher.plist.template"
+PLIST_DEST="$HOME/Library/LaunchAgents/com.joshuashew.xlsx-clip-watcher.plist"
+LABEL="com.joshuashew.xlsx-clip-watcher"
 STATE_DIR="$HOME/.local/state/xlsx-clip-watcher"
-LOG="$STATE_DIR/watcher.log"
 
+echo "=== install-xlsx-clip-watcher $(date '+%H:%M:%S') ==="
+echo "  dotfiles:  $DOTFILES_DIR"
+
+# 1. Create state dir so launchd can open the log file before the script runs
 mkdir -p "$STATE_DIR"
+echo "  state dir: $STATE_DIR"
 
-echo "=== install-xlsx-clip-watcher $(date +%H:%M:%S) ==="
-echo "  dotfiles: $DOTFILES_DIR"
-
-if ! command -v fswatch &>/dev/null; then
-    echo "  installing fswatch via brew..."
-    brew install fswatch || { echo "  ERROR: brew install fswatch failed"; exit 1; }
+# 2. Pre-warm uv cache for xlcat so the first real trigger doesn't stall
+echo "  warming xlcat uv cache..."
+if command -v uv &>/dev/null && [[ -x "$DOTFILES_DIR/bin/xlcat" ]]; then
+  echo '# dummy xlsx to warm cache' | \
+    timeout 60 uv run "$DOTFILES_DIR/bin/xlcat" /dev/null 2>/dev/null || true
+  echo "  xlcat: cache warm (exit ignored — /dev/null not a valid xlsx)"
+else
+  echo "  xlcat: skipped (uv or xlcat not found)"
 fi
-echo "  fswatch: $(command -v fswatch)"
 
-chmod +x "$SCRIPT"
+# 3. Remove legacy crontab entries (old design used @reboot + watchdog)
+if crontab -l 2>/dev/null | grep -q "xlsx-clip-watcher"; then
+  (crontab -l 2>/dev/null | grep -v "xlsx-clip-watcher") | crontab - && \
+    echo "  crontab: removed legacy entries" || \
+    echo "  crontab: could not remove (non-interactive — OK)"
+else
+  echo "  crontab: no legacy entries"
+fi
 
-# Stop any running instance (and its fswatch child) before restarting.
-pkill -f "xlsx-clip-watcher.sh" 2>/dev/null && echo "  watcher: stopped"
-pkill -f "fswatch.*Downloads" 2>/dev/null && echo "  fswatch: stopped"
-sleep 3
+# 4. Unload old agent (ignore errors if not loaded)
+launchctl unload "$PLIST_DEST" 2>/dev/null && echo "  agent: unloaded" || echo "  agent: was not loaded"
 
-# Delete the lock file so the new watcher gets a fresh inode.
-# Any surviving subshell still holds flock on the deleted inode (harmless).
-rm -f "$STATE_DIR/watcher.lock" && echo "  lock: cleared" 
+# Kill any leftover daemon-mode processes from the old design
+pkill -f "xlsx-clip-watcher.sh" 2>/dev/null && echo "  old process: stopped" || true
+pkill -f "fswatch.*Downloads"   2>/dev/null && echo "  fswatch: stopped"    || true
+rm -f "$STATE_DIR/watcher.lock"
 
-nohup /bin/bash "$SCRIPT" >> "$LOG" 2>&1 &
-echo "  watcher: started PID $!"
+# 5. Build plist from template (substitute DOTFILES_DIR and HOME_DIR)
+sed \
+  -e "s|DOTFILES_DIR|$DOTFILES_DIR|g" \
+  -e "s|HOME_DIR|$HOME|g" \
+  "$TEMPLATE" > "$PLIST_DEST"
+echo "  plist: installed → $PLIST_DEST"
 
-REBOOT_W="@reboot /bin/bash $SCRIPT >> $LOG 2>&1 &  # xlsx-clip-watcher"
-WATCHDOG_W="* * * * * flock -n $STATE_DIR/watcher.lock true && /bin/bash $SCRIPT >> $LOG 2>&1 &  # xlsx-clip-watcher"
-
-# crontab write may fail in non-interactive contexts (macOS permission model).
-# Non-fatal: crontab from the initial interactive install persists.
-(crontab -l 2>/dev/null | grep -v "xlsx-clip-watcher" || true
- echo "$REBOOT_W"
- echo "$WATCHDOG_W") | crontab - 2>/dev/null && echo "  crontab: updated" || echo "  crontab: skipped (non-interactive; prior entries still active)"
+# 6. Load the new agent
+launchctl load "$PLIST_DEST"
+echo "  agent: loaded"
 
 echo ""
-echo "Log: tail -f $LOG"
-echo "State: $STATE_DIR/seen.txt"
+echo "Watching ~/Downloads for ScheduleAtAGlance*.xlsx files."
+echo "Log: tail -f $STATE_DIR/watcher.log"
 echo "Done."

--- a/launchd/scripts/xlsx-clip-watcher.sh
+++ b/launchd/scripts/xlsx-clip-watcher.sh
@@ -1,73 +1,50 @@
 #!/usr/bin/env bash
-# xlsx-clip-watcher — FSEvents-based via fswatch (no polling)
-# Only processes .xlsx files in ~/Downloads whose name starts with "ScheduleAtAGlance".
-# On confirmed clip import, moves the file to Trash (not deleted).
-# Tracks files by device:inode so a re-downloaded file counts as new.
+# xlsx-clip-watcher — one-shot triggered by launchd WatchPaths.
+# Runs whenever ~/Downloads changes. Idempotent: tracks seen files by
+# device:inode so re-downloads of the same file are ignored.
 
-export PATH="$HOME/.local/bin:$HOME/bin:$HOME/.dotfiles/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin"
+export PATH="$HOME/.dotfiles/bin:$HOME/.local/bin:$HOME/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin"
 
 DOWNLOADS="$HOME/Downloads"
 STATE_DIR="$HOME/.local/state/xlsx-clip-watcher"
 SEEN_FILE="$STATE_DIR/seen.txt"
-LOCK_FILE="$STATE_DIR/watcher.lock"
 
 mkdir -p "$STATE_DIR"
 
-log() { echo "[xlsx-clip-watcher] $(date '+%Y-%m-%d %H:%M:%S') $*"; }
-
-# Kill entire process group on SIGTERM so fswatch and the while-loop subshell
-# (which inherit the flock fd) are cleaned up — otherwise pkill leaves orphans
-# that hold the lock and cause every restart to immediately exit.
-trap 'kill 0 2>/dev/null; exit 0' SIGTERM SIGINT
-
-exec 9>"$LOCK_FILE"
-if ! flock -n 9; then
-    log "another instance already running, exiting"
-    exit 0
-fi
-
-check_and_import() {
-    local new_inodes=()
-    local new_files=()
-    while IFS= read -r -d '' file; do
-        [[ -f "$file" ]] || continue
-        # Only process files starting with "ScheduleAtAGlance"
-        [[ "$(basename "$file")" == ScheduleAtAGlance* ]] || continue
-        local dev_inode
-        dev_inode=$(stat -f "%d:%i" "$file" 2>/dev/null) || continue
-        grep -qxF "$dev_inode" "$SEEN_FILE" 2>/dev/null && continue
-        log "new: $(basename "$file") (inode=$dev_inode)"
-        new_inodes+=("$dev_inode")
-        new_files+=("$file")
-    done < <(find "$DOWNLOADS" -maxdepth 1 -name "*.xlsx" -print0 2>/dev/null)
-
-    if [ "${#new_files[@]}" -gt 0 ]; then
-        log "running: clip import xlsx -d $DOWNLOADS"
-        if clip import xlsx -d "$DOWNLOADS"; then
-            printf '%s\n' "${new_inodes[@]}" >> "$SEEN_FILE"
-            # Move confirmed files to Trash (osascript primary, ~/.Trash fallback)
-            for f in "${new_files[@]}"; do
-                if osascript -e "tell application \"Finder\" to delete POSIX file \"$f\"" 2>/dev/null; then
-                    log "trashed: $(basename "$f")"
-                elif mv "$f" "$HOME/.Trash/" 2>/dev/null; then
-                    log "trashed (fallback): $(basename "$f")"
-                else
-                    log "WARNING: could not trash $f"
-                fi
-            done
-        else
-            log "ERROR: clip exited non-zero — inodes not marked seen, files not trashed"
-        fi
-    fi
+log() {
+  local msg="[xlsx-clip-watcher] $(date '+%Y-%m-%d %H:%M:%S') $*"
+  echo "$msg"
+  echo "$msg" >> "$STATE_DIR/watcher.log"
 }
 
-log "starting up (PID $$)"
-check_and_import
-log "startup scan complete, entering fswatch loop"
+log "triggered"
 
-fswatch -0 -e ".*" -i ".*\\.xlsx$" "$DOWNLOADS" | \
-while IFS= read -r -d '' _event; do
-    check_and_import
-done 9>&-
+processed=0
+while IFS= read -r -d '' file; do
+  [[ -f "$file" ]] || continue
+  [[ "$(basename "$file")" == ScheduleAtAGlance* ]] || continue
 
-log "fswatch exited unexpectedly (will be restarted by watchdog)"
+  dev_inode=$(stat -f "%d:%i" "$file" 2>/dev/null) || continue
+  grep -qxF "$dev_inode" "$SEEN_FILE" 2>/dev/null && continue
+
+  log "new: $(basename "$file") (inode=$dev_inode)"
+
+  # Pass the specific file — don't let xlcat guess from -d
+  if xlcat "$file" | pbcopy; then
+    printf '%s\n' "$dev_inode" >> "$SEEN_FILE"
+    log "imported to clipboard: $(basename "$file")"
+
+    if osascript -e "tell application \"Finder\" to delete POSIX file \"$file\"" 2>/dev/null; then
+      log "trashed: $(basename "$file")"
+    elif mv "$file" "$HOME/.Trash/" 2>/dev/null; then
+      log "trashed (fallback): $(basename "$file")"
+    else
+      log "WARNING: could not trash $(basename "$file")"
+    fi
+    processed=$((processed + 1))
+  else
+    log "ERROR: xlcat failed for $(basename "$file") — not marking seen"
+  fi
+done < <(find "$DOWNLOADS" -maxdepth 1 -name "*.xlsx" -print0 2>/dev/null)
+
+log "done ($processed processed)"


### PR DESCRIPTION
## Problems with old design

- **Two competing restart mechanisms**: LaunchAgent `KeepAlive` + crontab watchdog fighting over the lock file, causing unpredictable behavior on each restart
- **xlcat `-d` picks most-recently-modified xlsx**: not filtered by `ScheduleAtAGlance` name — imports wrong file if anything else newer is in Downloads
- **fswatch as a dependency**: extra process to manage, extra failure point
- **Log in `/tmp/`**: cleared on reboot, inaccessible to filesystem proxy, making remote diagnosis impossible
- **Empty state dir**: strong signal the service never ran successfully — silent failures throughout

## New design

**`WatchPaths` in plist** — launchd watches `~/Downloads` natively. No fswatch.

**One-shot script** — runs, finds unprocessed `ScheduleAtAGlance*.xlsx` files, exits. No daemon, no lock file, no restart complexity. Multiple triggers are safe (idempotent via seen.txt).

**Explicit file path to xlcat** — `xlcat "$file"` instead of `xlcat -d $DOWNLOADS`. Always imports the right file.

**Log in `~/.local/state/xlsx-clip-watcher/`** — persistent across reboots, accessible to filesystem proxy for remote inspection.

**Unified install script** — `bash ~/.dotfiles/launchd/install-xlsx-clip-watcher.sh` handles plist templating, uv pre-warm, legacy crontab cleanup, and launchctl reload in one step.

## To deploy after merge

```
cd ~/.dotfiles && git pull && bash launchd/install-xlsx-clip-watcher.sh
```
