### PR TITLE
fix: clipmerge f-string backslash SyntaxError

### DIFF
--- a/bin/clipmerge
+++ b/bin/clipmerge
@@ -237,10 +237,11 @@ def interactive_mode(db: ClipboardDB, limit: int = 30):
     # Show preview
     print(f"\nMerged result ({len(merged)} chars):")
     print("-" * 80)
-    preview_lines = merged.split('\n')[:10]
+    all_lines = merged.split('\n')
+    preview_lines = all_lines[:10]
     print('\n'.join(preview_lines))
-    if len(preview_lines) < len(merged.split('\n')):
-        print(f"... ({len(merged.split('\n')) - len(preview_lines)} more lines)")
+    if len(preview_lines) < len(all_lines):
+        print(f"... ({len(all_lines) - len(preview_lines)} more lines)")
     print("-" * 80)
 
     # Confirm


### PR DESCRIPTION
Python <3.12 rejects backslash escapes inside f-string expression parts.

Fix: extract `all_lines = merged.split('\n')` before the f-string. Also removes the redundant double-call to `split('\n')`.