### PR TITLE
feat: add -l/--limit to clipmerge top-level parser

### DIFF
--- a/bin/clipmerge
+++ b/bin/clipmerge
@@ -405,6 +405,9 @@ Notes:
         """.strip()
     )
 
+    parser.add_argument('-l', '--limit', type=int, default=30,
+                       help='Number of recent entries to show in interactive mode (default: 30)')
+
     subparsers = parser.add_subparsers(dest='mode', help='Operation mode')
 
     # Interactive mode (default)


### PR DESCRIPTION
Allows `clip merge -l 60` without needing the `interactive` subcommand. The subcommand path already had `-l`; this mirrors it on the root parser so the default invocation respects the flag.