### PR TITLE
fix: xlsx-clip-watcher: WatchPaths to StartInterval:5

### DIFF
--- a/launchd/agents/com.joshuashew.xlsx-clip-watcher.plist.template
+++ b/launchd/agents/com.joshuashew.xlsx-clip-watcher.plist.template
@@ -9,17 +9,16 @@
         <string>/bin/bash</string>
         <string>DOTFILES_DIR/launchd/scripts/xlsx-clip-watcher.sh</string>
     </array>
-    <!-- WatchPaths: launchd watches ~/Downloads natively; no fswatch needed -->
-    <key>WatchPaths</key>
-    <array>
-        <string>HOME_DIR/Downloads</string>
-    </array>
-    <!-- Run once at load to catch any file that landed before the agent started -->
+    <!-- Poll every 5 s. WatchPaths was dropped: macOS 12+ does not fire
+         WatchPaths reliably for browser downloads (Chrome/Safari write via
+         atomic temp-file rename; launchd fires on the crdownload/tmp appear,
+         not on the final xlsx rename, so every scan ran before the file
+         existed and logged "done (0 processed)"). StartInterval is slower
+         but 100% reliable. RunAtLoad catches files already present at load. -->
+    <key>StartInterval</key>
+    <integer>5</integer>
     <key>RunAtLoad</key>
     <true/>
-    <!-- Throttle: don't re-trigger more than once per 5 seconds -->
-    <key>ThrottleInterval</key>
-    <integer>5</integer>
     <!-- Log to state dir (created by install script before plist is loaded) -->
     <key>StandardOutPath</key>
     <string>HOME_DIR/.local/state/xlsx-clip-watcher/launchd.log</string>

--- a/launchd/scripts/xlsx-clip-watcher.sh
+++ b/launchd/scripts/xlsx-clip-watcher.sh
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
-# xlsx-clip-watcher — one-shot triggered by launchd WatchPaths.
-# Runs whenever ~/Downloads changes. Idempotent: tracks seen files by
-# device:inode so re-downloads of the same file are ignored.
+# xlsx-clip-watcher — one-shot polled by launchd StartInterval:5.
+# Runs every 5 seconds. Idempotent: tracks seen files by device:inode
+# so re-scans of the same file are ignored.
+# WatchPaths was dropped: macOS 12+ fires on the .crdownload temp file,
+# not on the final xlsx rename, so every scan ran before the file existed.
 
 export PATH="$HOME/.dotfiles/bin:$HOME/.local/bin:$HOME/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin"
 
@@ -16,8 +18,6 @@ log() {
   echo "$msg"
   echo "$msg" >> "$STATE_DIR/watcher.log"
 }
-
-log "triggered"
 
 processed=0
 while IFS= read -r -d '' file; do
@@ -47,4 +47,4 @@ while IFS= read -r -d '' file; do
   fi
 done < <(find "$DOWNLOADS" -maxdepth 1 -name "*.xlsx" -print0 2>/dev/null)
 
-log "done ($processed processed)"
+[[ $processed -gt 0 ]] && log "done ($processed processed)"


### PR DESCRIPTION
## Root cause

WatchPaths is unreliable for browser downloads on macOS 12+.

Chrome/Safari write files via an atomic temp-file rename: a .crdownload file appears first, then gets renamed to the final .xlsx. launchd's WatchPaths fires the agent on the temp-file creation event - not on the final rename. The script runs, does `find ~/Downloads -name "*.xlsx"`, finds nothing (file not renamed yet), and exits "done (0 processed)".

Evidence in watcher.log: every trigger since 2026-05-14 (the WatchPaths redesign) shows `done (0 processed)`. No xlsx files processed in ~6 days despite Downloads directory changes firing the agent.

## Fix

Replace WatchPaths (event-driven, broken) with StartInterval:5 (5-second polling). The script is already idempotent via dev:inode tracking in seen.txt, so polling is safe.

ThrottleInterval removed (only meaningful alongside WatchPaths).

## Noise reduction

With 5s polling, log would accumulate ~17,000 "done (0 processed)" lines/day. Now only logs when processed > 0.

## Deploy

After merging: POST /dotfiles/deploy on the credential proxy (pulls dotfiles + runs install script).